### PR TITLE
Fixes for MSVC

### DIFF
--- a/include/irr/core/alloc/HeterogenousMemoryAddressAllocatorAdaptor.h
+++ b/include/irr/core/alloc/HeterogenousMemoryAddressAllocatorAdaptor.h
@@ -92,7 +92,7 @@ namespace impl
 
 
 template<class AddressAllocator, class BufferAllocator, class HostAllocator=core::allocator<uint8_t> >
-class HeterogenousMemoryAddressAllocatorAdaptor : public impl::HeterogenousMemoryAddressAllocatorAdaptorBase<AddressAllocator,BufferAllocator,HostAllocator>, private AddressAllocator
+class HeterogenousMemoryAddressAllocatorAdaptor : public impl::HeterogenousMemoryAddressAllocatorAdaptorBase<AddressAllocator,BufferAllocator,HostAllocator>, /* This is supposed to be private inheritance */protected AddressAllocator
 {
         typedef impl::HeterogenousMemoryAddressAllocatorAdaptorBase<AddressAllocator,BufferAllocator,HostAllocator> ImplBase;
     protected:

--- a/include/irr/core/alloc/address_allocator_traits.h
+++ b/include/irr/core/alloc/address_allocator_traits.h
@@ -156,9 +156,9 @@ namespace core
 
             template<class U> struct has_func_get_real_addr<U,void_t<func_get_real_addr<U> > >  : std::is_same<func_get_real_addr<U>,size_type> {};
 
-            static inline constexpr bool         supportsArbitraryOrderFrees = resolve_supportsArbitraryOrderFrees<AddressAlloc>::value;
-            static inline constexpr uint32_t maxMultiOps                           = resolve_maxMultiOps<AddressAlloc>::value;
-            static inline constexpr bool         supportsNullBuffer                 = resolve_supportsNullBuffer<AddressAlloc>::value;
+            static constexpr bool         supportsArbitraryOrderFrees = resolve_supportsArbitraryOrderFrees<AddressAlloc>::value;
+            static constexpr uint32_t maxMultiOps                           = resolve_maxMultiOps<AddressAlloc>::value;
+            static constexpr bool         supportsNullBuffer                 = resolve_supportsNullBuffer<AddressAlloc>::value;
 
             static inline void          printDebugInfo()
             {

--- a/include/irr/core/alloc/address_allocator_traits.h
+++ b/include/irr/core/alloc/address_allocator_traits.h
@@ -156,9 +156,9 @@ namespace core
 
             template<class U> struct has_func_get_real_addr<U,void_t<func_get_real_addr<U> > >  : std::is_same<func_get_real_addr<U>,size_type> {};
 
-            static constexpr bool         supportsArbitraryOrderFrees = resolve_supportsArbitraryOrderFrees<AddressAlloc>::value;
-            static constexpr uint32_t maxMultiOps                           = resolve_maxMultiOps<AddressAlloc>::value;
-            static constexpr bool         supportsNullBuffer                 = resolve_supportsNullBuffer<AddressAlloc>::value;
+            static _IRR_STATIC_INLINE_CONSTEXPR constexpr bool         supportsArbitraryOrderFrees = resolve_supportsArbitraryOrderFrees<AddressAlloc>::value;
+            static _IRR_STATIC_INLINE_CONSTEXPR constexpr uint32_t     maxMultiOps                 = resolve_maxMultiOps<AddressAlloc>::value;
+            static _IRR_STATIC_INLINE_CONSTEXPR constexpr bool         supportsNullBuffer          = resolve_supportsNullBuffer<AddressAlloc>::value;
 
             static inline void          printDebugInfo()
             {

--- a/include/irr/core/alloc/address_allocator_traits.h
+++ b/include/irr/core/alloc/address_allocator_traits.h
@@ -20,14 +20,14 @@ namespace core
     struct address_type_traits<uint32_t>
     {
         address_type_traits() = delete;
-        static constexpr uint32_t   invalid_address = 0xdeadbeefu;
+        _IRR_STATIC_INLINE_CONSTEXPR uint32_t   invalid_address = 0xdeadbeefu;
     };
 
     template<>
     struct address_type_traits<uint64_t>
     {
         address_type_traits() = delete;
-        static constexpr uint64_t   invalid_address = 0xdeadbeefBADC0FFEull;
+        _IRR_STATIC_INLINE_CONSTEXPR uint64_t   invalid_address = 0xdeadbeefBADC0FFEull;
     };
 
 
@@ -156,9 +156,9 @@ namespace core
 
             template<class U> struct has_func_get_real_addr<U,void_t<func_get_real_addr<U> > >  : std::is_same<func_get_real_addr<U>,size_type> {};
 
-            static _IRR_STATIC_INLINE_CONSTEXPR constexpr bool         supportsArbitraryOrderFrees = resolve_supportsArbitraryOrderFrees<AddressAlloc>::value;
-            static _IRR_STATIC_INLINE_CONSTEXPR constexpr uint32_t     maxMultiOps                 = resolve_maxMultiOps<AddressAlloc>::value;
-            static _IRR_STATIC_INLINE_CONSTEXPR constexpr bool         supportsNullBuffer          = resolve_supportsNullBuffer<AddressAlloc>::value;
+            _IRR_STATIC_INLINE_CONSTEXPR bool         supportsArbitraryOrderFrees = resolve_supportsArbitraryOrderFrees<AddressAlloc>::value;
+            _IRR_STATIC_INLINE_CONSTEXPR uint32_t     maxMultiOps                 = resolve_maxMultiOps<AddressAlloc>::value;
+            _IRR_STATIC_INLINE_CONSTEXPR bool         supportsNullBuffer          = resolve_supportsNullBuffer<AddressAlloc>::value;
 
             static inline void          printDebugInfo()
             {

--- a/include/irr/macros.h
+++ b/include/irr/macros.h
@@ -8,6 +8,13 @@
 #include "IrrCompileConfig.h"
 #include "assert.h"
 
+//! MSVC doesn't accept constexpr inline constants (claims it's c+17 feature) and ld (this linker which comes with GCC compiler) generates 'undefined references' without inline while defining in header file
+#if defined(_MSC_VER)
+    #define _IRR_STATIC_INLINE_CONSTEXPR static constexpr
+#else
+    #define _IRR_STATIC_INLINE_CONSTEXPR static inline constexpr
+#endif
+
 //! For dumb MSVC which now has to keep a spec bug to avoid breaking existing source code
 #if defined(_MSC_VER)
     #define IRR_FORCE_EBO __declspec(empty_bases)

--- a/source/Irrlicht/CMeshSceneNodeInstanced.cpp
+++ b/source/Irrlicht/CMeshSceneNodeInstanced.cpp
@@ -222,10 +222,11 @@ uint32_t CMeshSceneNodeInstanced::addInstance(const core::matrix4x3& relativeTra
 
 bool CMeshSceneNodeInstanced::addInstances(uint32_t* instanceIDs, const size_t& instanceCount, const core::matrix4x3* relativeTransforms, const void* extraData)
 {
+    {//dummyBytes, aligns scope
     core::vector<uint32_t> dummyBytes_(instanceCount);
     core::vector<uint32_t> aligns_(instanceCount);
-    uint32_t* dummyBytes = dummyBytes_.data();
-    uint32_t* aligns = aligns_.data();
+    uint32_t* const dummyBytes = dummyBytes_.data();
+    uint32_t* const aligns = aligns_.data();
     for (size_t i=0; i<instanceCount; i++)
     {
         instanceIDs[i] = kInvalidInstanceID;
@@ -248,6 +249,7 @@ bool CMeshSceneNodeInstanced::addInstances(uint32_t* instanceIDs, const size_t& 
         }
         return false;
     }
+    }// end of arbitrary scope
 
     if (getCurrentInstanceCapacity()!=instanceBBoxesCount)
     {
@@ -374,12 +376,15 @@ void CMeshSceneNodeInstanced::removeInstances(const size_t& instanceCount, const
         instanceBBoxes[blockID].MaxEdge.set(-FLT_MAX,-FLT_MAX,-FLT_MAX);
     }
 
+    {//dummyBytes scope
     core::vector<uint32_t> dummyBytes_(instanceCount);
-    uint32_t* dummyBytes = dummyBytes_.data();
+    uint32_t* const dummyBytes = dummyBytes_.data();
     for (size_t i=0; i<instanceCount; i++)
         dummyBytes[i] = dataPerInstanceInputSize;
 
     instanceDataAllocator->multi_free_addr(instanceCount,instanceIDs,static_cast<const uint32_t*>(dummyBytes));
+    }
+
     if (getCurrentInstanceCapacity()!=instanceBBoxesCount)
     {
         size_t newCount = getCurrentInstanceCapacity();

--- a/source/Irrlicht/CMeshSceneNodeInstanced.cpp
+++ b/source/Irrlicht/CMeshSceneNodeInstanced.cpp
@@ -222,8 +222,10 @@ uint32_t CMeshSceneNodeInstanced::addInstance(const core::matrix4x3& relativeTra
 
 bool CMeshSceneNodeInstanced::addInstances(uint32_t* instanceIDs, const size_t& instanceCount, const core::matrix4x3* relativeTransforms, const void* extraData)
 {
-    uint32_t dummyBytes[instanceCount];
-    uint32_t aligns[instanceCount];
+    core::vector<uint32_t> dummyBytes_(instanceCount);
+    core::vector<uint32_t> aligns_(instanceCount);
+    uint32_t* dummyBytes = dummyBytes_.data();
+    uint32_t* aligns = aligns_.data();
     for (size_t i=0; i<instanceCount; i++)
     {
         instanceIDs[i] = kInvalidInstanceID;
@@ -372,7 +374,8 @@ void CMeshSceneNodeInstanced::removeInstances(const size_t& instanceCount, const
         instanceBBoxes[blockID].MaxEdge.set(-FLT_MAX,-FLT_MAX,-FLT_MAX);
     }
 
-    uint32_t dummyBytes[instanceCount];
+    core::vector<uint32_t> dummyBytes_(instanceCount);
+    uint32_t* dummyBytes = dummyBytes_.data();
     for (size_t i=0; i<instanceCount; i++)
         dummyBytes[i] = dataPerInstanceInputSize;
 


### PR DESCRIPTION
* inline vars is cpp17 feature
* variable size array
* put protected inheritance instead of private in HeterogenousMemoryAddressAllocatorAdaptor