### PR TITLE
Update CMake: find and enable vulkan

### DIFF
--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -384,11 +384,14 @@ endif()
 find_package(Vulkan)
 
 if (Vulkan_FOUND)
+	message(STATUS "Building with Vulkan driver")
 	target_compile_definitions(Irrlicht PRIVATE
 		_IRR_COMPILE_WITH_VULKAN_
 	)
 	#target_link_libraries(Irrlicht INTERFACE Vulkan::Vulkan) # this should work, but it doesn't
 	target_link_libraries(Irrlicht INTERFACE ${Vulkan_LIBRARY})
+else()
+	message(STATUS "Vulkan driver is not enabled")
 endif()
 
 target_compile_definitions(Irrlicht PRIVATE

--- a/source/Irrlicht/CMakeLists.txt
+++ b/source/Irrlicht/CMakeLists.txt
@@ -381,6 +381,16 @@ if (UNIX)
 		${X11_xf86vmode_INCLUDE_PATH})
 endif()
 
+find_package(Vulkan)
+
+if (Vulkan_FOUND)
+	target_compile_definitions(Irrlicht PRIVATE
+		_IRR_COMPILE_WITH_VULKAN_
+	)
+	#target_link_libraries(Irrlicht INTERFACE Vulkan::Vulkan) # this should work, but it doesn't
+	target_link_libraries(Irrlicht INTERFACE ${Vulkan_LIBRARY})
+endif()
+
 target_compile_definitions(Irrlicht PRIVATE
 	_IRR_STATIC_LIB_
 	_IRR_COMPILE_WITH_OPENGL_


### PR DESCRIPTION
Verified with generated makefile, have definition and library (add, not overwrite).
Not sure why `target_link_libraries(Irrlicht INTERFACE Vulkan::Vulkan)` (new CMake syntax) doesn't work though, maybe because of the CMake version, so using traditional command.